### PR TITLE
Set properties recursively

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -407,11 +407,18 @@ class SceneNode {
         } else if (property == "top_color" || property == "bottom_color") {
             this.object[property] = value.map((x) => x * 255);
         } else {
-            let v = this.object;
-            for (const p in property.split('.')) {
-                v = v[p];
+            function smart_set(obj, is, value) {
+                if (is.length !== 1) {
+                    return smart_set(obj[is[0]], is.slice(1), value);
+                }
+                if (value instanceof Array && obj[is[0]] instanceof THREE.Color) {
+                    return obj[is[0]].setRGB(value[0], value[1], value[2]);
+                } else if (typeof obj[is[0]].set === "function") {
+                    return obj[is[0]].set(value);
+                }
+                return obj[is[0]] = value;
             }
-            v = value;
+            smart_set(this.object, property.split('.'), value);
         }
         this.vis_controller.updateDisplay();
         this.controllers.forEach(c => c.updateDisplay());

--- a/src/index.js
+++ b/src/index.js
@@ -407,7 +407,11 @@ class SceneNode {
         } else if (property == "top_color" || property == "bottom_color") {
             this.object[property] = value.map((x) => x * 255);
         } else {
-            this.object[property] = value;
+            let v = this.object;
+            for (const p in property.split('.')) {
+                v = v[p];
+            }
+            v = value;
         }
         this.vis_controller.updateDisplay();
         this.controllers.forEach(c => c.updateDisplay());


### PR DESCRIPTION
This PR allows modifying member variables of the object, examples:

```
obj._set_property('material.color.b', 1)  # change only the blue channel of the color
obj1._set_property('material.color', [0, 1, 0]) # change the color of the material
obj1._set_property('material.opacity', 0.5) # change the opacity of the material
```

How it works:
 - it splits strings based on dots to access internal variables, e.g., 'material.color.g' results in accessing variable 'g' of object `this.object.material.color`
 - if the accessed object is of type color and the value is an array, use set.RGB()
 - if the accessed object has a function set, use it to set the properties
 - otherwise, use the assignment operator to change the value