### PR TITLE
Fix .gitignore typo for main.dist.js license file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 dist/main.js
-dist/min.min.js.LICENSE.txt
+dist/main.min.js.LICENSE.txt
 yarn-error.log


### PR DESCRIPTION
Following what was said on #159 